### PR TITLE
Add eslint-plugin-vue with one rule

### DIFF
--- a/packages/eslint-plugin-vue/.eslintrc.js
+++ b/packages/eslint-plugin-vue/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  env: { node: true },
+  extends: [
+    '@quero/eslint-config-base',
+  ],
+};

--- a/packages/eslint-plugin-vue/.eslintrc.js
+++ b/packages/eslint-plugin-vue/.eslintrc.js
@@ -1,5 +1,9 @@
 module.exports = {
   env: { node: true },
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaVersion: 11,
+  },
   extends: [
     '@quero/eslint-config-base',
   ],

--- a/packages/eslint-plugin-vue/.gitignore
+++ b/packages/eslint-plugin-vue/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/packages/eslint-plugin-vue/README.md
+++ b/packages/eslint-plugin-vue/README.md
@@ -33,6 +33,12 @@ The rule window, should export a function that is the rule you are developing.
 For more information on how to create your first rule, see [How To Write Your
 First ESLint Plugin](https://dev.to/spukas/how-to-write-your-first-eslint-plugin-145).
 
+More resources that are an interesting read before/while:
+- [AST for html's template reference](https://github.com/mysticatea/vue-eslint-parser/blob/master/docs/ast.md)
+- [Vue's official rules](https://github.com/vuejs/eslint-plugin-vue)
+- [ESLint rule tester](https://eslint.org/docs/developer-guide/nodejs-api#ruletester)
+- [ESLint doc for configuration](https://eslint.org/docs/user-guide/configuring)
+
 ## Rules
 
 ### `template-kebab-name-for-unregistered-components`

--- a/packages/eslint-plugin-vue/README.md
+++ b/packages/eslint-plugin-vue/README.md
@@ -4,14 +4,9 @@ This project is for rules that we decided to implement ourselves.
 
 ## Developing
 
-For constructing and testing the rule, we can use a tool called [`AST
-explorer`](https://astexplorer.net/). The AST stats for an abstract syntax tree
-which is a representation of the source code in a programming language.
+For constructing and testing the rule, we can use a tool called [`AST explorer`](https://astexplorer.net/). The AST stats for an abstract syntax tree which is a representation of the source code in a programming language.
 
-When accessing the AST explorer, remember to set the transformer to `ESLint v4`
-(and the parser to `eslint-babel`, but this should be set automatically once
-you choose `ESLint v4`). When this is done, you should see 4 windows in the
-explorer:
+When accessing the AST explorer, remember to set the transformer to `ESLint v4` (and the parser to `eslint-babel`, but this should be set automatically once you choose `ESLint v4`). When this is done, you should see 4 windows in the explorer:
 
 ```
 +-[top left]---------------+-[top right]--------------+
@@ -30,12 +25,11 @@ explorer:
 
 The rule window, should export a function that is the rule you are developing.
 
-For more information on how to create your first rule, see [How To Write Your
-First ESLint Plugin](https://dev.to/spukas/how-to-write-your-first-eslint-plugin-145).
+For more information on how to create your first rule, see [How To Write Your First ESLint Plugin](https://dev.to/spukas/how-to-write-your-first-eslint-plugin-145).
 
 More resources that are an interesting read before/while:
 - [AST for html's template reference](https://github.com/mysticatea/vue-eslint-parser/blob/master/docs/ast.md)
-- [Vue's official rules](https://github.com/vuejs/eslint-plugin-vue)
+- [Vue's official eslint rules (the README is good)](https://github.com/vuejs/eslint-plugin-vue)
 - [ESLint rule tester](https://eslint.org/docs/developer-guide/nodejs-api#ruletester)
 - [ESLint doc for configuration](https://eslint.org/docs/user-guide/configuring)
 
@@ -45,12 +39,10 @@ More resources that are an interesting read before/while:
 
 <details>
 <summary>
-Enforce the use of kebab-case for naming global components in
-<code>&lt;template&gt;</code>.
+Enforce the use of kebab-case for naming global components in <code>&lt;template&gt;</code>.
 </summary>
 
-This ensures that we have a clear distinction between components that are
-declared locally vs components that we have to search the project for.
+This ensures that we have a clear distinction between components that are declared locally vs components that we have to search the project for.
 
 </details>
 

--- a/packages/eslint-plugin-vue/README.md
+++ b/packages/eslint-plugin-vue/README.md
@@ -1,0 +1,34 @@
+# `@quero/eslint-plugin-vue`
+
+This project is for rules that we decided to implement ourselves.
+
+## Developing
+
+For constructing and testing the rule, we can use a tool called [`AST
+explorer`](https://astexplorer.net/). The AST stats for an abstract syntax tree
+which is a representation of the source code in a programming language.
+
+When accessing the AST explorer, remember to set the transformer to `ESLint v4`
+(and the parser to `eslint-babel`, but this should be set automatically once
+you choose `ESLint v4`). When this is done, you should see 4 windows in the
+explorer:
+
+```
++-[top left]---------------+-[top right]--------------+
+| Is used to write a       | Is the explorer of the   |
+| source code.             | source code. On hover    |
+|                          | you should see the       |
+|                          | highlighted parts in     |
+|                          | your code.               |
++--------------------------+--------------------------+
+| Is the rule.             | Is the output after the  |
+|                          | rule, that runs against  |
+|                          | the code.                |
+|                          |                          |
++-[bottom left]------------+-[bottom right]-----------+
+```
+
+The rule window, should export a function that is the rule you are developing.
+
+For more information on how to create your first rule, see [How To Write Your
+First ESLint Plugin](https://dev.to/spukas/how-to-write-your-first-eslint-plugin-145).

--- a/packages/eslint-plugin-vue/README.md
+++ b/packages/eslint-plugin-vue/README.md
@@ -9,7 +9,14 @@ This project is for rules that we decided to implement ourselves.
 <a name="rules"></a>
 ## Rules
 
-### `template-kebab-name-for-unregistered-components`
+Legend:
+
+| icon      | meaning           |
+| ----      | -------           |
+| :wrench:  | Fixable           |
+| :wrench:* | Partially fixable |
+
+### `template-kebab-name-for-unregistered-components` :wrench:*
 
 <details>
 <summary>
@@ -17,6 +24,8 @@ Enforce the use of kebab-case for naming global components in <code>&lt;template
 </summary>
 
 This ensures that we have a clear distinction between components that are declared locally vs components that we have to search the project for.
+
+This rule is fixable, but only if the component don't have any `extend` declaration, because if thats the case, we cannot see which components are being loaded or not.
 
 </details>
 

--- a/packages/eslint-plugin-vue/README.md
+++ b/packages/eslint-plugin-vue/README.md
@@ -32,3 +32,35 @@ The rule window, should export a function that is the rule you are developing.
 
 For more information on how to create your first rule, see [How To Write Your
 First ESLint Plugin](https://dev.to/spukas/how-to-write-your-first-eslint-plugin-145).
+
+## Rules
+
+### `template-kebab-name-for-unregistered-components`
+
+```vue
+<template>
+  <div>
+    <!-- BAD -->
+    <GlobalComponent></GlobalComponent>
+    <local-component></local-component>
+
+    <!-- GOOD -->
+    <global-component></global-component>
+    <LocalComponent></LocalComponent>
+  </div>
+</template>
+
+<script>
+const LocalComponent = {
+  render(h) {
+    return h('div');
+  },
+};
+
+export default {
+  components: {
+    LocalComponent,
+  },
+}
+</script>
+```

--- a/packages/eslint-plugin-vue/README.md
+++ b/packages/eslint-plugin-vue/README.md
@@ -43,6 +43,17 @@ More resources that are an interesting read before/while:
 
 ### `template-kebab-name-for-unregistered-components`
 
+<details>
+<summary>
+Enforce the use of kebab-case for naming global components in
+<code>&lt;template&gt;</code>.
+</summary>
+
+This ensures that we have a clear distinction between components that are
+declared locally vs components that we have to search the project for.
+
+</details>
+
 ```vue
 <template>
   <div>

--- a/packages/eslint-plugin-vue/README.md
+++ b/packages/eslint-plugin-vue/README.md
@@ -2,37 +2,11 @@
 
 This project is for rules that we decided to implement ourselves.
 
-## Developing
+**Content:**
+- [Rules](#rules)
+- [Developing](#developing)
 
-For constructing and testing the rule, we can use a tool called [`AST explorer`](https://astexplorer.net/). The AST stats for an abstract syntax tree which is a representation of the source code in a programming language.
-
-When accessing the AST explorer, remember to set the transformer to `ESLint v4` (and the parser to `eslint-babel`, but this should be set automatically once you choose `ESLint v4`). When this is done, you should see 4 windows in the explorer:
-
-```
-+-[top left]---------------+-[top right]--------------+
-| Is used to write a       | Is the explorer of the   |
-| source code.             | source code. On hover    |
-|                          | you should see the       |
-|                          | highlighted parts in     |
-|                          | your code.               |
-+--------------------------+--------------------------+
-| Is the rule.             | Is the output after the  |
-|                          | rule, that runs against  |
-|                          | the code.                |
-|                          |                          |
-+-[bottom left]------------+-[bottom right]-----------+
-```
-
-The rule window, should export a function that is the rule you are developing.
-
-For more information on how to create your first rule, see [How To Write Your First ESLint Plugin](https://dev.to/spukas/how-to-write-your-first-eslint-plugin-145).
-
-More resources that are an interesting read before/while:
-- [AST for html's template reference](https://github.com/mysticatea/vue-eslint-parser/blob/master/docs/ast.md)
-- [Vue's official eslint rules (the README is good)](https://github.com/vuejs/eslint-plugin-vue)
-- [ESLint rule tester](https://eslint.org/docs/developer-guide/nodejs-api#ruletester)
-- [ESLint doc for configuration](https://eslint.org/docs/user-guide/configuring)
-
+<a name="rules"></a>
 ## Rules
 
 ### `template-kebab-name-for-unregistered-components`
@@ -73,3 +47,35 @@ export default {
 }
 </script>
 ```
+
+<a name="developing"></a>
+## Developing
+
+For constructing and testing the rule, we can use a tool called [`AST explorer`](https://astexplorer.net/). The AST stats for an abstract syntax tree which is a representation of the source code in a programming language.
+
+When accessing the AST explorer, remember to set the transformer to `ESLint v4` (and the parser to `eslint-babel`, but this should be set automatically once you choose `ESLint v4`). When this is done, you should see 4 windows in the explorer:
+
+```
++-[top left]---------------+-[top right]--------------+
+| Is used to write a       | Is the explorer of the   |
+| source code.             | source code. On hover    |
+|                          | you should see the       |
+|                          | highlighted parts in     |
+|                          | your code.               |
++--------------------------+--------------------------+
+| Is the rule.             | Is the output after the  |
+|                          | rule, that runs against  |
+|                          | the code.                |
+|                          |                          |
++-[bottom left]------------+-[bottom right]-----------+
+```
+
+The rule window, should export a function that is the rule you are developing.
+
+For more information on how to create your first rule, see [How To Write Your First ESLint Plugin](https://dev.to/spukas/how-to-write-your-first-eslint-plugin-145).
+
+More resources that are an interesting read before/while:
+- [AST for html's template reference](https://github.com/mysticatea/vue-eslint-parser/blob/master/docs/ast.md)
+- [Vue's official eslint rules (the README is good)](https://github.com/vuejs/eslint-plugin-vue)
+- [ESLint rule tester](https://eslint.org/docs/developer-guide/nodejs-api#ruletester)
+- [ESLint doc for configuration](https://eslint.org/docs/user-guide/configuring)

--- a/packages/eslint-plugin-vue/package-lock.json
+++ b/packages/eslint-plugin-vue/package-lock.json
@@ -13,6 +13,47 @@
         "@babel/highlight": "^7.10.1"
       }
     },
+    "@babel/generator": {
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
+      "integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.2",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
+      "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.10.1",
+        "@babel/template": "^7.10.1",
+        "@babel/types": "^7.10.1"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
+      "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.1"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+      "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.1"
+      }
+    },
     "@babel/helper-validator-identifier": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
@@ -41,6 +82,59 @@
             "supports-color": "^5.3.0"
           }
         }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+      "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+      "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.1",
+        "@babel/parser": "^7.10.1",
+        "@babel/types": "^7.10.1"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
+      "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.1",
+        "@babel/generator": "^7.10.1",
+        "@babel/helper-function-name": "^7.10.1",
+        "@babel/helper-split-export-declaration": "^7.10.1",
+        "@babel/parser": "^7.10.1",
+        "@babel/types": "^7.10.1",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+      "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.1",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "@quero/eslint-config-base": {
@@ -123,6 +217,20 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
+    },
+    "babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -525,6 +633,11 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "html-tag-names": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/html-tag-names/-/html-tag-names-1.1.5.tgz",
+      "integrity": "sha512-aI5tKwNTBzOZApHIynaAwecLBv8TlZTEy/P4Sj2SzzAhBrGuI8yGZ0UIXVPQzOHGS+to2mjb04iy6VWt/8+d8A=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -688,6 +801,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -699,6 +818,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "just-kebab-case": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/just-kebab-case/-/just-kebab-case-1.1.0.tgz",
+      "integrity": "sha512-QkuwuBMQ9BQHMUEkAtIA4INLrkmnnveqlFB1oFi09gbU0wBdZo6tTnyxNWMR84zHxBuwK7GLAwqN8nrvVxOLTA=="
     },
     "levn": {
       "version": "0.4.1",
@@ -811,6 +935,11 @@
         "callsites": "^3.0.0"
       }
     },
+    "pascalcase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-1.0.0.tgz",
+      "integrity": "sha512-BSExi0rRnCHReJys6NocaK+cfTXNinAegfWBvr0JD3hiaEG7Nuc7r0CIdOJunXrs8gU/sbHQ9dxVAtiVQisjmg=="
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -821,6 +950,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "prelude-ls": {
@@ -846,6 +981,15 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -939,6 +1083,12 @@
         }
       }
     },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -979,6 +1129,11 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "svg-tag-names": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/svg-tag-names/-/svg-tag-names-2.0.1.tgz",
+      "integrity": "sha512-BEZ508oR+X/b5sh7bT0RqDJ7GhTpezjj3P1D4kugrOaPs6HijviWksoQ63PS81vZn0QCjZmVKjHDBniTo+Domg=="
     },
     "table": {
       "version": "5.4.6",
@@ -1052,6 +1207,12 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "tslib": {
       "version": "1.13.0",

--- a/packages/eslint-plugin-vue/package-lock.json
+++ b/packages/eslint-plugin-vue/package-lock.json
@@ -1,0 +1,1123 @@
+{
+  "name": "@quero/eslint-plugin-vue",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+      "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.1"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+      "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+      "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.1",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
+    },
+    "@quero/eslint-config-base": {
+      "version": "file:../eslint-config-base",
+      "dev": true
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "acorn": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
+      "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-escapes": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.2.0.tgz",
+      "integrity": "sha512-B3BtEyaDKC5MlfDa2Ha8/D6DsS4fju95zs0hjS3HdGazw+LNayai38A25qMppK37wWGWNYSPOR6oYzlz5MHsRQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.1.0",
+        "eslint-utils": "^2.0.0",
+        "eslint-visitor-keys": "^1.2.0",
+        "espree": "^7.1.0",
+        "esquery": "^1.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+      "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.2.0.tgz",
+      "integrity": "sha512-WFb4ihckKil6hu3Dp798xdzSfddwKKU3+nGniKF6HfeW6OLd2OUDEPP7TcHtB5+QXOKg2s6B2DaMPE1Nn/kxKQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.1.0.tgz",
+      "integrity": "sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.2.0",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.2.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
+          "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "regexpp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
+    "rxjs": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
+      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+      "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tslib": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "v8-compile-cache": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "dev": true
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    }
+  }
+}

--- a/packages/eslint-plugin-vue/package-lock.json
+++ b/packages/eslint-plugin-vue/package-lock.json
@@ -1250,6 +1250,33 @@
       "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
       "dev": true
     },
+    "vue-eslint-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.1.0.tgz",
+      "integrity": "sha512-Kr21uPfthDc63nDl27AGQEhtt9VrZ9nkYk/NTftJ2ws9XiJwzJJCnCr3AITQ2jpRMA0XPGDECxYH8E027qMK9Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "eslint-scope": "^5.0.0",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.2.1",
+        "esquery": "^1.0.1",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "espree": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+          "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+          "dev": true,
+          "requires": {
+            "acorn": "^7.1.1",
+            "acorn-jsx": "^5.2.0",
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        }
+      }
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",

--- a/packages/eslint-plugin-vue/package.json
+++ b/packages/eslint-plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quero/eslint-plugin-vue",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A bunch of rules we decided to create ourselves",
   "main": "src/index.js",
   "scripts": {

--- a/packages/eslint-plugin-vue/package.json
+++ b/packages/eslint-plugin-vue/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@quero/eslint-plugin-vue",
+  "version": "1.0.0",
+  "description": "A bunch of rules we decided to create ourselves",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "eslint",
+    "vue",
+    "rules"
+  ],
+  "author": "",
+  "license": "MIT"
+}

--- a/packages/eslint-plugin-vue/package.json
+++ b/packages/eslint-plugin-vue/package.json
@@ -2,7 +2,7 @@
   "name": "@quero/eslint-plugin-vue",
   "version": "1.0.0",
   "description": "A bunch of rules we decided to create ourselves",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "eslint -R ."
   },
@@ -15,6 +15,13 @@
   "license": "MIT",
   "devDependencies": {
     "@quero/eslint-config-base": "file:../eslint-config-base",
+    "babel-eslint": "^10.1.0",
     "eslint": "^7.2.0"
+  },
+  "dependencies": {
+    "html-tag-names": "^1.1.5",
+    "just-kebab-case": "^1.1.0",
+    "pascalcase": "^1.0.0",
+    "svg-tag-names": "^2.0.1"
   }
 }

--- a/packages/eslint-plugin-vue/package.json
+++ b/packages/eslint-plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quero/eslint-plugin-vue",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A bunch of rules we decided to create ourselves",
   "main": "src/index.js",
   "scripts": {

--- a/packages/eslint-plugin-vue/package.json
+++ b/packages/eslint-plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quero/eslint-plugin-vue",
-  "version": "1.0.3-beta.2",
+  "version": "1.0.3-beta.3",
   "description": "A bunch of rules we decided to create ourselves",
   "main": "src/index.js",
   "scripts": {

--- a/packages/eslint-plugin-vue/package.json
+++ b/packages/eslint-plugin-vue/package.json
@@ -19,7 +19,8 @@
   "devDependencies": {
     "@quero/eslint-config-base": "file:../eslint-config-base",
     "babel-eslint": "^10.1.0",
-    "eslint": "^7.2.0"
+    "eslint": "^7.2.0",
+    "vue-eslint-parser": "^7.1.0"
   },
   "dependencies": {
     "html-tag-names": "^1.1.5",

--- a/packages/eslint-plugin-vue/package.json
+++ b/packages/eslint-plugin-vue/package.json
@@ -4,7 +4,7 @@
   "description": "A bunch of rules we decided to create ourselves",
   "main": "src/index.js",
   "scripts": {
-    "test": "eslint -R ."
+    "test": "eslint . && npx ./tests/**/*.js"
   },
   "repository": {
     "url": "git+https://github.com/quero-edu/guidelines.git"

--- a/packages/eslint-plugin-vue/package.json
+++ b/packages/eslint-plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quero/eslint-plugin-vue",
-  "version": "1.0.3-beta.4",
+  "version": "1.0.3",
   "description": "A bunch of rules we decided to create ourselves",
   "main": "src/index.js",
   "scripts": {

--- a/packages/eslint-plugin-vue/package.json
+++ b/packages/eslint-plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quero/eslint-plugin-vue",
-  "version": "1.0.2",
+  "version": "1.0.3-beta.1",
   "description": "A bunch of rules we decided to create ourselves",
   "main": "src/index.js",
   "scripts": {

--- a/packages/eslint-plugin-vue/package.json
+++ b/packages/eslint-plugin-vue/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "eslint -R ."
   },
+  "repository": {
+    "url": "git+https://github.com/quero-edu/guidelines.git"
+  },
   "keywords": [
     "eslint",
     "vue",

--- a/packages/eslint-plugin-vue/package.json
+++ b/packages/eslint-plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quero/eslint-plugin-vue",
-  "version": "1.0.3-beta.1",
+  "version": "1.0.3-beta.2",
   "description": "A bunch of rules we decided to create ourselves",
   "main": "src/index.js",
   "scripts": {

--- a/packages/eslint-plugin-vue/package.json
+++ b/packages/eslint-plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quero/eslint-plugin-vue",
-  "version": "1.0.3-beta.3",
+  "version": "1.0.3-beta.4",
   "description": "A bunch of rules we decided to create ourselves",
   "main": "src/index.js",
   "scripts": {

--- a/packages/eslint-plugin-vue/package.json
+++ b/packages/eslint-plugin-vue/package.json
@@ -4,7 +4,7 @@
   "description": "A bunch of rules we decided to create ourselves",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "eslint -R ."
   },
   "keywords": [
     "eslint",
@@ -12,5 +12,9 @@
     "rules"
   ],
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "@quero/eslint-config-base": "file:../eslint-config-base",
+    "eslint": "^7.2.0"
+  }
 }

--- a/packages/eslint-plugin-vue/src/index.js
+++ b/packages/eslint-plugin-vue/src/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'template-kebab-name-for-unregistered-components': require('./rules/template-kebab-name-for-unregistered-components'),
+  },
+};

--- a/packages/eslint-plugin-vue/src/rules/template-kebab-name-for-unregistered-components.js
+++ b/packages/eslint-plugin-vue/src/rules/template-kebab-name-for-unregistered-components.js
@@ -6,6 +6,7 @@ const kebabcase = require('just-kebab-case');
 module.exports = {
   create(context) {
     const localregisteredComponents = [];
+    let isVueFile = false;
 
     // Don't know why this is necessary, but a really respectable open source
     // lib does this token jiggle every time, so...
@@ -14,6 +15,8 @@ module.exports = {
 
     return context.parserServices.defineTemplateBodyVisitor({
       VElement(node) {
+        if (!isVueFile) return;
+
         const name = node.rawName;
         const open = tokens.getFirstToken(node.startTag);
 
@@ -47,7 +50,12 @@ module.exports = {
         });
       },
     }, {
+      Program(node) {
+        isVueFile = node.hasOwnProperty('templateBody');
+      },
       ExportDefaultDeclaration(node) {
+        if (!isVueFile) return;
+
         const { properties } = node.declaration;
 
         const components = properties

--- a/packages/eslint-plugin-vue/src/rules/template-kebab-name-for-unregistered-components.js
+++ b/packages/eslint-plugin-vue/src/rules/template-kebab-name-for-unregistered-components.js
@@ -29,7 +29,7 @@ module.exports = {
         context.report({
           node: open,
           loc: open.loc,
-          message: 'Component name "{{name}}", is not kebab-case. Name it "{{kebabcased}}" or register it locally',
+          message: 'Component name "{{name}}" is not kebab-case. Name it "{{kebabcased}}" or register it locally',
           data: { name, kebabcased },
           fix(fixer) {
             const endTag = node.endTag;

--- a/packages/eslint-plugin-vue/src/rules/template-kebab-name-for-unregistered-components.js
+++ b/packages/eslint-plugin-vue/src/rules/template-kebab-name-for-unregistered-components.js
@@ -58,7 +58,7 @@ module.exports = {
 
         const { properties } = node.declaration;
 
-        const components = (((properties
+        const components = ((((properties || [])
           .find(property => property.key.name === 'components') || {})
           .value || {})
           .properties || [])

--- a/packages/eslint-plugin-vue/src/rules/template-kebab-name-for-unregistered-components.js
+++ b/packages/eslint-plugin-vue/src/rules/template-kebab-name-for-unregistered-components.js
@@ -7,6 +7,7 @@ module.exports = {
   create(context) {
     const localregisteredComponents = [];
     let isVueFile = false;
+    let isExtended = false;
 
     // Don't know why this is necessary, but a really respectable open source
     // lib does this token jiggle every time, so...
@@ -35,6 +36,8 @@ module.exports = {
           message: 'Component name "{{name}}" is not kebab-case. Name it "{{kebabcased}}" or register it locally',
           data: { name, kebabcased },
           fix(fixer) {
+            if (isExtended) return;
+
             const endTag = node.endTag;
 
             if (!endTag) {
@@ -56,9 +59,11 @@ module.exports = {
       ExportDefaultDeclaration(node) {
         if (!isVueFile) return;
 
-        const { properties } = node.declaration;
+        const properties = node.declaration.properties || [];
 
-        const components = ((((properties || [])
+        isExtended = properties.find(property => property.key.name === 'extends');
+
+        const components = (((properties
           .find(property => property.key.name === 'components') || {})
           .value || {})
           .properties || [])

--- a/packages/eslint-plugin-vue/src/rules/template-kebab-name-for-unregistered-components.js
+++ b/packages/eslint-plugin-vue/src/rules/template-kebab-name-for-unregistered-components.js
@@ -1,0 +1,63 @@
+const HTML_TAG_NAMES = require('html-tag-names');
+const SVG_TAG_NAMES = require('svg-tag-names');
+const pascalcase = require('pascalcase');
+const kebabcase = require('just-kebab-case');
+
+module.exports = {
+  create(context) {
+    const localregisteredComponents = [];
+
+    // Don't know why this is necessary, but a really respectable open source
+    // lib does this token jiggle every time, so...
+    const tokens = context.parserServices.getTemplateBodyTokenStore
+      && context.parserServices.getTemplateBodyTokenStore();
+
+    return context.parserServices.defineTemplateBodyVisitor({
+      VElement(node) {
+        const name = node.rawName;
+        const open = tokens.getFirstToken(node.startTag);
+
+        if (localregisteredComponents.includes(pascalcase(name))) return;
+        if (HTML_TAG_NAMES.includes(name)) return;
+        if (SVG_TAG_NAMES.includes(name)) return;
+
+        const kebabcased = kebabcase(name);
+
+        const isKebabCasedAlready = kebabcased === name;
+        if (isKebabCasedAlready) return;
+
+        context.report({
+          node: open,
+          loc: open.loc,
+          message: 'Component name "{{name}}", is not kebab-case. Name it "{{kebabcased}}" or register it locally',
+          data: { name, kebabcased },
+          fix(fixer) {
+            const endTag = node.endTag;
+
+            if (!endTag) {
+              return fixer.replaceText(open, `<${kebabcased}`);
+            }
+
+            const endTagOpen = tokens.getFirstToken(endTag);
+            return [
+              fixer.replaceText(open, `<${kebabcased}`),
+              fixer.replaceText(endTagOpen, `<${kebabcased}`),
+            ];
+          },
+        });
+      },
+    }, {
+      ExportDefaultDeclaration(node) {
+        const { properties } = node.declaration;
+
+        const components = properties
+          .find(property => property.key.name === 'components')
+          .value
+          .properties
+          .map(component => component.key.name);
+
+        localregisteredComponents.push(...components);
+      },
+    });
+  },
+};

--- a/packages/eslint-plugin-vue/src/rules/template-kebab-name-for-unregistered-components.js
+++ b/packages/eslint-plugin-vue/src/rules/template-kebab-name-for-unregistered-components.js
@@ -44,7 +44,7 @@ module.exports = {
             const endTagOpen = tokens.getFirstToken(endTag);
             return [
               fixer.replaceText(open, `<${kebabcased}`),
-              fixer.replaceText(endTagOpen, `<${kebabcased}`),
+              fixer.replaceText(endTagOpen, `</${kebabcased}`),
             ];
           },
         });

--- a/packages/eslint-plugin-vue/src/rules/template-kebab-name-for-unregistered-components.js
+++ b/packages/eslint-plugin-vue/src/rules/template-kebab-name-for-unregistered-components.js
@@ -58,10 +58,10 @@ module.exports = {
 
         const { properties } = node.declaration;
 
-        const components = properties
-          .find(property => property.key.name === 'components')
-          .value
-          .properties
+        const components = (((properties
+          .find(property => property.key.name === 'components') || {})
+          .value || {})
+          .properties || [])
           .map(component => component.key.name);
 
         localregisteredComponents.push(...components);

--- a/packages/eslint-plugin-vue/tests/rules/template-kebab-name-for-unregistered-components.js
+++ b/packages/eslint-plugin-vue/tests/rules/template-kebab-name-for-unregistered-components.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const rule = require('../../src/rules/template-kebab-name-for-unregistered-components');
+const RuleTester = require('eslint').RuleTester;
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: {
+    ecmaVersion: 11,
+    sourceType: 'module',
+  },
+});
+
+tester.run('template-kebab-name-for-unregistered-components', rule, {
+  valid: [
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <!-- ✓ GOOD -->
+          <CoolComponent />
+          <cool-component />
+          <unregistered-component />
+          <div></div>
+          <h1></h1>
+          <svg></svg>
+        </template>
+        <script>
+        export default {
+          components: {
+            CoolComponent
+          }
+        }
+        </script>
+      `,
+    },
+  ],
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <!-- ✓ GOOD -->
+          <CoolComponent />
+          <cool-component />
+          <unregistered-component />
+
+          <!-- ✗ BAD -->
+          <UnregisteredComponent />
+        </template>
+        <script>
+        export default {
+          components: {
+            CoolComponent
+          }
+        }
+        </script>
+      `,
+      errors: [{
+        message: 'Component name "UnregisteredComponent" is not kebab-case. Name it "unregistered-component" or register it locally',
+        line: 9,
+        column: 11,
+        endLine: 9,
+        endColumn: 33,
+      }],
+      output: `
+        <template>
+          <!-- ✓ GOOD -->
+          <CoolComponent />
+          <cool-component />
+          <unregistered-component />
+
+          <!-- ✗ BAD -->
+          <unregistered-component />
+        </template>
+        <script>
+        export default {
+          components: {
+            CoolComponent
+          }
+        }
+        </script>
+      `,
+    },
+  ],
+});

--- a/packages/eslint-plugin-vue/tests/rules/template-kebab-name-for-unregistered-components.js
+++ b/packages/eslint-plugin-vue/tests/rules/template-kebab-name-for-unregistered-components.js
@@ -53,6 +53,25 @@ tester.run('template-kebab-name-for-unregistered-components', rule, {
       `,
     },
     {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <!-- ✓ GOOD -->
+          <cool-component />
+          <unregistered-component />
+          <div></div>
+          <h1></h1>
+          <svg></svg>
+        </template>
+        <script>
+        const Bla = {
+          name: 'what-ever',
+        };
+        export default Bla;
+        </script>
+      `,
+    },
+    {
       filename: 'test.js',
       code: `
         export default function (to, from, savedPosition) {

--- a/packages/eslint-plugin-vue/tests/rules/template-kebab-name-for-unregistered-components.js
+++ b/packages/eslint-plugin-vue/tests/rules/template-kebab-name-for-unregistered-components.js
@@ -35,6 +35,24 @@ tester.run('template-kebab-name-for-unregistered-components', rule, {
       `,
     },
     {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <!-- ✓ GOOD -->
+          <cool-component />
+          <unregistered-component />
+          <div></div>
+          <h1></h1>
+          <svg></svg>
+        </template>
+        <script>
+        export default {
+          name: 'what-ever',
+        }
+        </script>
+      `,
+    },
+    {
       filename: 'test.js',
       code: `
         export default function (to, from, savedPosition) {

--- a/packages/eslint-plugin-vue/tests/rules/template-kebab-name-for-unregistered-components.js
+++ b/packages/eslint-plugin-vue/tests/rules/template-kebab-name-for-unregistered-components.js
@@ -142,6 +142,12 @@ tester.run('template-kebab-name-for-unregistered-components', rule, {
         column: 11,
         endLine: 9,
         endColumn: 33,
+      }, {
+        message: 'Component name "UnregisteredComponent" is not kebab-case. Name it "unregistered-component" or register it locally',
+        line: 10,
+        column: 11,
+        endLine: 10,
+        endColumn: 33,
       }],
       output: `
         <template>
@@ -156,6 +162,62 @@ tester.run('template-kebab-name-for-unregistered-components', rule, {
         </template>
         <script>
         export default {
+          components: {
+            CoolComponent
+          }
+        }
+        </script>
+      `,
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <!-- ✓ GOOD -->
+          <CoolComponent />
+          <cool-component />
+          <unregistered-component />
+
+          <!-- ✗ BAD -->
+          <UnregisteredComponent />
+          <UnregisteredComponent></UnregisteredComponent>
+        </template>
+        <script>
+        export default {
+          extends: AnotherComponent,
+          components: {
+            CoolComponent
+          }
+        }
+        </script>
+      `,
+      errors: [{
+        message: 'Component name "UnregisteredComponent" is not kebab-case. Name it "unregistered-component" or register it locally',
+        line: 9,
+        column: 11,
+        endLine: 9,
+        endColumn: 33,
+      }, {
+        message: 'Component name "UnregisteredComponent" is not kebab-case. Name it "unregistered-component" or register it locally',
+        line: 10,
+        column: 11,
+        endLine: 10,
+        endColumn: 33,
+      }],
+      output: `
+        <template>
+          <!-- ✓ GOOD -->
+          <CoolComponent />
+          <cool-component />
+          <unregistered-component />
+
+          <!-- ✗ BAD -->
+          <UnregisteredComponent />
+          <UnregisteredComponent></UnregisteredComponent>
+        </template>
+        <script>
+        export default {
+          extends: AnotherComponent,
           components: {
             CoolComponent
           }

--- a/packages/eslint-plugin-vue/tests/rules/template-kebab-name-for-unregistered-components.js
+++ b/packages/eslint-plugin-vue/tests/rules/template-kebab-name-for-unregistered-components.js
@@ -126,6 +126,7 @@ tester.run('template-kebab-name-for-unregistered-components', rule, {
 
           <!-- ✗ BAD -->
           <UnregisteredComponent />
+          <UnregisteredComponent></UnregisteredComponent>
         </template>
         <script>
         export default {
@@ -151,6 +152,7 @@ tester.run('template-kebab-name-for-unregistered-components', rule, {
 
           <!-- ✗ BAD -->
           <unregistered-component />
+          <unregistered-component></unregistered-component>
         </template>
         <script>
         export default {

--- a/packages/eslint-plugin-vue/tests/rules/template-kebab-name-for-unregistered-components.js
+++ b/packages/eslint-plugin-vue/tests/rules/template-kebab-name-for-unregistered-components.js
@@ -34,6 +34,48 @@ tester.run('template-kebab-name-for-unregistered-components', rule, {
         </script>
       `,
     },
+    {
+      filename: 'test.js',
+      code: `
+        export default function (to, from, savedPosition) {
+          // if the returned position is falsy or an empty object,
+          // will retain current scroll position.
+          let position = false;
+
+          // if no children detected
+          if (to.matched.length < 2) {
+            // scroll to the top of the page
+            position = { x: 0, y: 0 };
+          } else if (to.matched.some(r => r.components.default.options.scrollToTop)) {
+            // if one of the children has scrollToTop option set to true
+            position = { x: 0, y: 0 };
+          }
+
+          // savedPosition is only available for popstate navigations (back button)
+          if (savedPosition) {
+            position = savedPosition;
+          }
+
+          if ((from.name === 'cpdp' || from.name === 'pdp') && to.name === 'pdp') {
+            position = false;
+          }
+
+          return new Promise((resolve) => {
+            // wait for the out transition to complete (if necessary)
+            window.$nuxt.$once('triggerScroll', () => {
+              // coords will be used if no selector is provided,
+              // or if the selector didn't match any element.
+              if (to.hash && document.querySelector(to.hash)) {
+                // scroll to anchor by returning the selector
+                position = { selector: to.hash };
+              }
+
+              resolve(position);
+            });
+          });
+        }
+      `,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
# `@quero/eslint-plugin-vue`

This project is for rules that we decided to implement ourselves.

## Developing

For constructing and testing the rule, we can use a tool called [`AST
explorer`](https://astexplorer.net/). The AST stats for an abstract syntax tree
which is a representation of the source code in a programming language.

When accessing the AST explorer, remember to set the transformer to `ESLint v4`
(and the parser to `eslint-babel`, but this should be set automatically once
you choose `ESLint v4`). When this is done, you should see 4 windows in the
explorer:

```
+-[top left]---------------+-[top right]--------------+
| Is used to write a       | Is the explorer of the   |
| source code.             | source code. On hover    |
|                          | you should see the       |
|                          | highlighted parts in     |
|                          | your code.               |
+--------------------------+--------------------------+
| Is the rule.             | Is the output after the  |
|                          | rule, that runs against  |
|                          | the code.                |
|                          |                          |
+-[bottom left]------------+-[bottom right]-----------+
```

The rule window, should export a function that is the rule you are developing.

For more information on how to create your first rule, see [How To Write Your
First ESLint Plugin](https://dev.to/spukas/how-to-write-your-first-eslint-plugin-145).

More resources that are an interesting read before/while:
- [AST for html's template reference](https://github.com/mysticatea/vue-eslint-parser/blob/master/docs/ast.md)
- [Vue's official rules](https://github.com/vuejs/eslint-plugin-vue)
- [ESLint rule tester](https://eslint.org/docs/developer-guide/nodejs-api#ruletester)
- [ESLint doc for configuration](https://eslint.org/docs/user-guide/configuring)

## Rules

### `template-kebab-name-for-unregistered-components`

<details>
<summary>
Enforce the use of kebab-case for naming global components in
<code>&lt;template&gt;</code>.
</summary>

This ensures that we have a clear distinction between components that are
declared locally vs components that we have to search the project for.

</details>

```vue
<template>
  <div>
    <!-- BAD -->
    <GlobalComponent></GlobalComponent>
    <local-component></local-component>

    <!-- GOOD -->
    <global-component></global-component>
    <LocalComponent></LocalComponent>
  </div>
</template>

<script>
const LocalComponent = {
  render(h) {
    return h('div');
  },
};

export default {
  components: {
    LocalComponent,
  },
}
</script>
```
