### PR TITLE
Add rule for eslint vue

### DIFF
--- a/packages/eslint-plugin-vue/README.md
+++ b/packages/eslint-plugin-vue/README.md
@@ -84,15 +84,15 @@ delete the unused component on this case.
 With the default configuration everything will pass. But if a `deprecate`
 option is provided like the example bellow; every component named
 "deprecate-component-name" will trigger a warn to be substituted by
-"subistituted-component"
+"substituted-component"
 
 ```json
 {
   "rules": {
     "@quero/vue/deprecate-components-in-favor-of": ["warn", {
       "deprecate": {
-        "deprecated-component-name": "subistituted-component",
-        "AnotherExample": "subistituted-component"
+        "deprecated-component-name": "substituted-component",
+        "AnotherExample": "substituted-component"
       }
     }]
   }

--- a/packages/eslint-plugin-vue/README.md
+++ b/packages/eslint-plugin-vue/README.md
@@ -57,6 +57,78 @@ export default {
 </script>
 ```
 
+### `deprecate-components-in-favor-of`
+
+<details>
+<summary>
+A nice reminder on the lint that you shouldn't use this component, use the
+other one instead
+</summary>
+
+It's super recommended running this rule as `warn`, otherwise, what would be
+the point of using this rule at all if the rule will fail everything? Just
+delete the unused component on this case.
+
+</details>
+
+#### Default
+
+```json
+{
+  "rules": {
+    "@quero/vue/deprecate-components-in-favor-of": ["warn", { }]
+  }
+}
+```
+
+With the default configuration everything will pass. But if a `deprecate`
+option is provided like the example bellow; every component named
+"deprecate-component-name" will trigger a warn to be substituted by
+"subistituted-component"
+
+```json
+{
+  "rules": {
+    "@quero/vue/deprecate-components-in-favor-of": ["warn", {
+      "deprecate": {
+        "deprecated-component-name": "subistituted-component",
+        "AnotherExample": "subistituted-component"
+      }
+    }]
+  }
+}
+```
+
+```vue
+<template>
+  <div>
+    <!-- BAD -->
+    <DeprecatedComponentName></GlobalComponeDeprecatedComponentName>
+    <deprecated-component-name></deprecated-component-name>
+    <deprecated-component-name />
+    <AnotherExample />
+    <another-example />
+
+    <!-- GOOD -->
+    <!-- literally anything else -->
+  </div>
+</template>
+
+<script>
+const LocalComponent = {
+  render(h) {
+    return h('div');
+  },
+};
+
+export default {
+  components: {
+    LocalComponent,
+  },
+}
+</script>
+```
+
 <a name="developing"></a>
 ## Developing
 

--- a/packages/eslint-plugin-vue/package.json
+++ b/packages/eslint-plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quero/eslint-plugin-vue",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "A bunch of rules we decided to create ourselves",
   "main": "src/index.js",
   "scripts": {

--- a/packages/eslint-plugin-vue/src/index.js
+++ b/packages/eslint-plugin-vue/src/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
     'template-kebab-name-for-unregistered-components': require('./rules/template-kebab-name-for-unregistered-components'),
+    'deprecate-components-in-favor-of': require('./rules/deprecate-components-in-favor-of'),
   },
 };

--- a/packages/eslint-plugin-vue/src/rules/deprecate-components-in-favor-of.js
+++ b/packages/eslint-plugin-vue/src/rules/deprecate-components-in-favor-of.js
@@ -1,0 +1,49 @@
+const kebabcase = require('just-kebab-case');
+
+function normalizeKeysInKebab(object) {
+  return Object.fromEntries(Object.entries(object).map(([key, value]) => {
+    return [kebabcase(key), value];
+  }));
+}
+
+module.exports = {
+  create(context) {
+    const deprecate = normalizeKeysInKebab(
+      context.options[0] && context.options[0].deprecate || {},
+    );
+
+    let hasTemplateToLint = false;
+
+    // Don't know why this is necessary, but a really respectable open source
+    // lib does this token jiggle every time, so...
+    const tokens = context.parserServices.getTemplateBodyTokenStore
+      && context.parserServices.getTemplateBodyTokenStore();
+
+    return context.parserServices.defineTemplateBodyVisitor({
+      VElement(node) {
+        if (!hasTemplateToLint) return;
+
+        const name = node.rawName;
+        const open = tokens.getFirstToken(node.startTag);
+
+        const kebabName = kebabcase(name);
+
+        if (!Boolean(deprecate[kebabName])) return;
+
+        context.report({
+          node: open,
+          loc: open.loc,
+          message: 'Component "{{current}}" is deprecated, please use "{{substitute}}" instead',
+          data: {
+            current: name,
+            substitute: deprecate[kebabName],
+          },
+        });
+      },
+    }, {
+      Program(node) {
+        hasTemplateToLint = node.hasOwnProperty('templateBody');
+      },
+    });
+  },
+};

--- a/packages/eslint-plugin-vue/tests/rules/deprecate-components-in-favor-of.js
+++ b/packages/eslint-plugin-vue/tests/rules/deprecate-components-in-favor-of.js
@@ -1,0 +1,176 @@
+'use strict';
+
+const rule = require('../../src/rules/deprecate-components-in-favor-of');
+const { tester } = require('../tester');
+
+tester.run('deprecate-components-in-favor-of', rule, {
+  valid: [
+    { // without any options it pass
+      filename: 'test.vue',
+      code: `
+        <template>
+          <!-- ✓ GOOD -->
+          <CoolComponent />
+          <cool-component />
+          <unregistered-component />
+          <div></div>
+          <h1></h1>
+          <svg></svg>
+        </template>
+        <script>
+        export default {
+          components: {
+            CoolComponent
+          }
+        }
+        </script>
+      `,
+    },
+    { // with a configuration that is valid
+      filename: 'test.vue',
+      code: `
+        <template>
+          <!-- ✓ GOOD -->
+          <cool-component />
+          <unregistered-component />
+          <div></div>
+          <h1></h1>
+          <svg></svg>
+        </template>
+        <script>
+        export default {
+          name: 'what-ever',
+        }
+        </script>
+      `,
+      options: [{
+        deprecate: {
+          'unused-component': 'cooler-component',
+          'AlsoUnusedComponentButInPascal': 'cooler-component',
+        },
+      }],
+    },
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <!-- ✓ GOOD -->
+          <cool-component />
+          <unregistered-component />
+          <div></div>
+          <h1></h1>
+          <svg></svg>
+        </template>
+        <script>
+        const Bla = {
+          name: 'what-ever',
+        };
+        export default Bla;
+        </script>
+      `,
+    },
+    { // Pass in files that are not .vue files
+      filename: 'test.js',
+      code: `
+        export default function (to, from, savedPosition) {
+          // if the returned position is falsy or an empty object,
+          // will retain current scroll position.
+          let position = false;
+
+          // if no children detected
+          if (to.matched.length < 2) {
+            // scroll to the top of the page
+            position = { x: 0, y: 0 };
+          } else if (to.matched.some(r => r.components.default.options.scrollToTop)) {
+            // if one of the children has scrollToTop option set to true
+            position = { x: 0, y: 0 };
+          }
+
+          // savedPosition is only available for popstate navigations (back button)
+          if (savedPosition) {
+            position = savedPosition;
+          }
+
+          if ((from.name === 'cpdp' || from.name === 'pdp') && to.name === 'pdp') {
+            position = false;
+          }
+
+          return new Promise((resolve) => {
+            // wait for the out transition to complete (if necessary)
+            window.$nuxt.$once('triggerScroll', () => {
+              // coords will be used if no selector is provided,
+              // or if the selector didn't match any element.
+              if (to.hash && document.querySelector(to.hash)) {
+                // scroll to anchor by returning the selector
+                position = { selector: to.hash };
+              }
+
+              resolve(position);
+            });
+          });
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      filename: 'test.vue',
+      code: `
+        <template>
+          <!-- ✓ GOOD -->
+          <CoolComponent />
+          <cool-component />
+          <unregistered-component />
+
+          <!-- ✗ BAD -->
+          <UnregisteredComponent />
+          <UnregisteredComponent></UnregisteredComponent>
+        </template>
+        <script>
+        export default {
+          components: {
+            CoolComponent
+          }
+        }
+        </script>
+      `,
+      options: [{
+        deprecate: {
+          'UnregisteredComponent': 'cool-component',
+          'cool-component': 'cooler-component',
+        },
+      }],
+      errors: [{
+        message: 'Component "CoolComponent" is deprecated, please use "cooler-component" instead',
+        line: 4,
+        endLine: 4,
+        column: 11,
+        endColumn: 25,
+      }, {
+        message: 'Component "cool-component" is deprecated, please use "cooler-component" instead',
+        line: 5,
+        endLine: 5,
+        column: 11,
+        endColumn: 26,
+      }, {
+        message: 'Component "unregistered-component" is deprecated, please use "cool-component" instead',
+        line: 6,
+        endLine: 6,
+        column: 11,
+        endColumn: 34,
+      }, {
+        message: 'Component "UnregisteredComponent" is deprecated, please use "cool-component" instead',
+        line: 9,
+        column: 11,
+        endLine: 9,
+        endColumn: 33,
+      }, {
+        message: 'Component "UnregisteredComponent" is deprecated, please use "cool-component" instead',
+        line: 10,
+        column: 11,
+        endLine: 10,
+        endColumn: 33,
+      }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-vue/tests/rules/template-kebab-name-for-unregistered-components.js
+++ b/packages/eslint-plugin-vue/tests/rules/template-kebab-name-for-unregistered-components.js
@@ -1,15 +1,7 @@
 'use strict';
 
 const rule = require('../../src/rules/template-kebab-name-for-unregistered-components');
-const RuleTester = require('eslint').RuleTester;
-
-const tester = new RuleTester({
-  parser: require.resolve('vue-eslint-parser'),
-  parserOptions: {
-    ecmaVersion: 11,
-    sourceType: 'module',
-  },
-});
+const { tester } = require('../tester');
 
 tester.run('template-kebab-name-for-unregistered-components', rule, {
   valid: [

--- a/packages/eslint-plugin-vue/tests/tester.js
+++ b/packages/eslint-plugin-vue/tests/tester.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+
+const tester = new RuleTester({
+  parser: require.resolve('vue-eslint-parser'),
+  parserOptions: {
+    ecmaVersion: 11,
+    sourceType: 'module',
+  },
+});
+
+module.exports = { tester };


### PR DESCRIPTION
Dada essa configuração, agora a gente depreca todas as versões de carousel que a gente tinha no projeto e passa a usar o carousel do design system :D (o eslint passa a dar um warn quando você usa o componente deprecado)

```js
{
  "rules": {
    '@quero/vue/deprecate-components-in-favor-of': ['warn', {
      'deprecate': {
        'QCarousel': 'z-carousel',
        'QShowcaseCarousel': 'z-carousel',
        'SimpleCarousel': 'z-carousel',
      },
    }]
  }
}
```

output from lint:

```

> qb-render@1.0.0 lint /home/vinicius/src/qb-render
> eslint --ext .js,.vue . --cache


/file/path.vue
  38:7  warning  Component "QCarousel" is deprecated, please use "z-carousel" instead  @quero/vue/deprecate-components-in-favor-of

/file/path.vue
  12:7  warning  Component "QShowcaseCarousel" is deprecated, please use "z-carousel" instead  @quero/vue/deprecate-components-in-favor-of

/file/path.vue
  25:5  warning  Component "QShowcaseCarousel" is deprecated, please use "z-carousel" instead  @quero/vue/deprecate-components-in-favor-of

/file/path.vue
  2:3  warning  Component "QShowcaseCarousel" is deprecated, please use "z-carousel" instead  @quero/vue/deprecate-components-in-favor-of

/file/path.vue
  25:5  warning  Component "QShowcaseCarousel" is deprecated, please use "z-carousel" instead  @quero/vue/deprecate-components-in-favor-of

/file/path.vue
  6:5  warning  Component "QShowcaseCarousel" is deprecated, please use "z-carousel" instead  @quero/vue/deprecate-components-in-favor-of

/file/path.vue
  46:13  warning  Component "QShowcaseCarousel" is deprecated, please use "z-carousel" instead  @quero/vue/deprecate-components-in-favor-of

✖ 7 problems (0 errors, 7 warnings)
```