### PR TITLE
chore(stylelint): add sass rules

### DIFF
--- a/packages/stylelint-config-base/package-lock.json
+++ b/packages/stylelint-config-base/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quero/stylelint-config-base",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -45,6 +45,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -54,6 +59,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
     },
     "lodash": {
       "version": "4.17.20",
@@ -70,6 +80,27 @@
         "supports-color": "^6.1.0"
       }
     },
+    "postcss-media-query-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
+    },
+    "postcss-resolve-nested-selector": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+      "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4="
+    },
+    "postcss-selector-parser": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
+      "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+      "requires": {
+        "cssesc": "^3.0.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1",
+        "util-deprecate": "^1.0.2"
+      }
+    },
     "postcss-sorting": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-5.0.1.tgz",
@@ -78,6 +109,11 @@
         "lodash": "^4.17.14",
         "postcss": "^7.0.17"
       }
+    },
+    "postcss-value-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
     },
     "source-map": {
       "version": "0.6.1",
@@ -94,6 +130,18 @@
         "postcss-sorting": "^5.0.1"
       }
     },
+    "stylelint-scss": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.19.0.tgz",
+      "integrity": "sha512-Ic5bsmpS4wVucOw44doC1Yi9f5qbeVL4wPFiEOaUElgsOuLEN6Ofn/krKI8BeNL2gAn53Zu+IcVV4E345r6rBw==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
     "supports-color": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -101,6 +149,16 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     }
   }
 }

--- a/packages/stylelint-config-base/package.json
+++ b/packages/stylelint-config-base/package.json
@@ -12,6 +12,7 @@
     "stylelint": ">= 13.0.0"
   },
   "dependencies": {
-    "stylelint-order": "^4.1.0"
+    "stylelint-order": "^4.1.0",
+    "stylelint-scss": "^3.19.0"
   }
 }

--- a/packages/stylelint-config-base/stylelint.config.js
+++ b/packages/stylelint-config-base/stylelint.config.js
@@ -1,5 +1,8 @@
 module.exports = {
-  plugins: ['stylelint-order'],
+  plugins: [
+    'stylelint-order',
+    'stylelint-scss'
+  ],
   rules: {
     'at-rule-empty-line-before': [
       'always',
@@ -10,7 +13,7 @@ module.exports = {
     ],
     'at-rule-name-case': 'lower',
     'at-rule-name-space-after': 'always-single-line',
-    'at-rule-no-unknown': true,
+    'at-rule-no-unknown': null,
     'at-rule-semicolon-newline-after': 'always',
     'block-closing-brace-empty-line-before': 'never',
     'block-closing-brace-newline-after': 'always',
@@ -113,6 +116,7 @@ module.exports = {
         ignore: ['after-comment'],
       },
     ],
+    'scss/at-rule-no-unknown': true,
     'selector-attribute-brackets-space-inside': 'never',
     'selector-attribute-operator-space-after': 'never',
     'selector-attribute-operator-space-before': 'never',
@@ -131,6 +135,7 @@ module.exports = {
     'selector-type-case': 'lower',
     'selector-type-no-unknown': true,
     'string-no-newline': true,
+    'string-quotes': 'single',
     'unit-case': 'lower',
     'unit-no-unknown': true,
     'value-keyword-case': 'lower',


### PR DESCRIPTION
Eu to adicionando o stylelint da quero la no pacote do zilla-core: https://github.com/quero-edu/zilla/pull/545

mas a regra `at-rule-no-unknown` não conhece as keywords do sass como `@extend`, `@mixin`, etc...

Ao invés de colocar todas essas palavras para a regra ignorar eu preferi colocar [esse plugin](https://github.com/kristerkari/stylelint-scss) que ja faz isso.

O legal desse plugin é que ele possui outras regras para a linguagem sass que podem ser uteis,.