### PR TITLE
:sparkles: Add react/jsx-newline rule

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -27,6 +27,7 @@ module.exports = {
     'react/jsx-closing-bracket-location': ['error', 'line-aligned'],
     'react/jsx-first-prop-new-line': ['error', 'multiline'],
     'react/jsx-max-props-per-line': ['error', { maximum: 1, when: 'always' }],
+    'react/jsx-newline': ['error', { prevent: true }],
   },
 };
 


### PR DESCRIPTION
PR para adicionar [essa regra](https://github.com/yannickcr/eslint-plugin-react/blob/HEAD/docs/rules/jsx-newline.md) com a intencão de melhorar a legibilidade do código.

Essa regra forca uma linha entre os componentes e expressões.