### PR TITLE
Fix jsx-newline rule config

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -27,7 +27,7 @@ module.exports = {
     'react/jsx-closing-bracket-location': ['error', 'line-aligned'],
     'react/jsx-first-prop-new-line': ['error', 'multiline'],
     'react/jsx-max-props-per-line': ['error', { maximum: 1, when: 'always' }],
-    'react/jsx-newline': ['error', { prevent: true }],
+    'react/jsx-newline': ['error', { prevent: false }],
   },
 };
 


### PR DESCRIPTION
Puts pessoal, comi bola aqui, deveria estar com a opcão `{ prevent: false }` para que forcasse a linha em branco entre os componentes :/