### PR TITLE
Fix: use @typescript-eslint semi rule

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -28,6 +28,7 @@ module.exports = {
       'error',
       'single'
     ],
+    '@typescript-eslint/semi': ['error'],
     '@typescript-eslint/triple-slash-reference': 'error',
     '@typescript-eslint/unified-signatures': 'error',
     'camelcase': 'error',
@@ -65,6 +66,7 @@ module.exports = {
       'error',
       'never'
     ],
+    'semi': 'off',
     'valid-typeof': 'off',
     'use-isnan': 'error',
   },


### PR DESCRIPTION
Encontrei esse bug enquanto aplicava as regras do lint a um projeto:
https://github.com/typescript-eslint/typescript-eslint/issues/123

A solução recomendada foi utilizar a regra `semi` do `@typescript-eslint`
https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/semi.md