### PR TITLE
feat: allow any in template expressions

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -34,6 +34,13 @@ module.exports = {
     '@typescript-eslint/prefer-function-type': 'error',
     '@typescript-eslint/prefer-namespace-keyword': 'error',
     '@typescript-eslint/prefer-regexp-exec': 'off',
+    '@typescript-eslint/restrict-template-expressions': ['error', {
+      'allowNumber': true,
+      'allowBoolean': false,
+      'allowAny': true,
+      'allowNullish': false,
+      'allowRegExp': false,
+    }],
     '@typescript-eslint/triple-slash-reference': 'error',
     '@typescript-eslint/unified-signatures': 'error',
     'complexity': 'warn',


### PR DESCRIPTION
I ran into a lot of problems logging error messages, as they are treated as `any`. Is anyone against turning this rule off, for `any` types?
![image](https://user-images.githubusercontent.com/45714268/140186365-11f4c2bd-f083-40e3-8dd5-fe19f7f42b57.png)

A workarround I have been using is to tell typescript to treat `error.message` as a string, but it's kinda bothersome to go back and fix every single case, and (IMO) makes the codebase a bit ugglier.

I only changed the value of `allowAny`, the rest is set to the default
https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/restrict-template-expressions.md#options