### PR TITLE
fix(typescript): no-duplicate-imports conflict with consistent-type-imports

### DIFF
--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -14,6 +14,10 @@ module.exports = {
   },
   rules: {
     'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
+
+    // This rule conflicts with consistent-type-imports, it is safe to disable as there is a typescript specific counterpart.
+    'no-duplicate-imports': 'off',
+
     'import/no-duplicates': ['error', { 'considerQueryString': true }],
 
     // It is safe to disable this rule when using TypeScript because TypeScript's compiler enforces this check.

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -15,9 +15,8 @@ module.exports = {
   rules: {
     'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
 
-    // This rule conflicts with consistent-type-imports, it is safe to disable as there is a typescript specific counterpart.
+    // Turning off vanilla no-duplicate-imports in favor of imports/no-duplicate to support `import type` syntax properly
     'no-duplicate-imports': 'off',
-
     'import/no-duplicates': ['error', { 'considerQueryString': true }],
 
     // It is safe to disable this rule when using TypeScript because TypeScript's compiler enforces this check.


### PR DESCRIPTION
* O que esta PR faz / Porque nós precisamos fazer isso?
`no-duplicate-imports` gera um conflito com `consistent-type-imports`, já existe um plugin específico para typescript em uso para este caso, então podemos desligar essa regra (`imports/no-duplicate`)
<img width="704" alt="image" src="https://github.com/quero-edu/guidelines/assets/45714268/ea12b4cf-d0be-4a18-9ecd-e7f007a892ed">
<img width="942" alt="image" src="https://github.com/quero-edu/guidelines/assets/45714268/4ec63f82-cbea-44a6-89a8-b85ca80b50e5">

Desligando ela não temos mais o erro entre type imports/imports normais:
<img width="1228" alt="image" src="https://github.com/quero-edu/guidelines/assets/45714268/87587207-6964-4528-8f79-f44619282945">

E ainda checamos imports duplicados:
<img width="1073" alt="image" src="https://github.com/quero-edu/guidelines/assets/45714268/89371684-e9ad-46b8-a301-d3b53c3a89b9">


* Que tipo de mudança foi introduzida?

- [x] Bugfix 🐛 
- [ ] Feature ✨ 
- [ ] Refactor 🔨 
- [ ] Build-Mudança relatada 🔖 
- [ ] Outro, por favor descrever:


* Que tipo de teste foi implementado? ✅ 


- [ ] Unitário
- [ ] Integração/Headless
- [x] Nenhum, porque: Não há testes para o eslint-typescript ainda (ou pelo menos eu não encontrei)


**Em caso de dúvidas consultar a documentação.**
